### PR TITLE
Replaced stringstream stod and stoi implementation

### DIFF
--- a/src/datatable.cpp
+++ b/src/datatable.cpp
@@ -260,6 +260,10 @@ std::vector<double> DataTable::getVectorY() const
 
 void DataTable::save(std::string fileName) const
 {
+
+    // To give a consistent format across all locales, use the C locale when saving and loading
+    std::locale current_locale = std::locale::global(std::locale("C"));
+
     std::ofstream outFile;
 
     try
@@ -302,10 +306,16 @@ void DataTable::save(std::string fileName) const
     {
         throw;
     }
+
+    std::locale::global(current_locale);
 }
 
 void DataTable::load(std::string fileName)
 {
+
+    // To give a consistent format across all locales, use the C locale when saving and loading
+    std::locale current_locale = std::locale::global(std::locale("C"));
+
     std::ifstream inFile;
 
     try
@@ -329,10 +339,12 @@ void DataTable::load(std::string fileName)
     {
         // Look for comment sign
         if(line.at(0) == '#')
+        {
             continue;
+        }
 
         // Reading number of dimensions
-        if(state == 0)
+        else if(state == 0)
         {
             nX = checked_strtol(line.c_str(), nullptr, 10);
             nY = 1;
@@ -372,6 +384,8 @@ void DataTable::load(std::string fileName)
     {
         throw;
     }
+
+    std::locale::global(current_locale);
 }
 
 /**************


### PR DESCRIPTION
Replaced stringstream stod and stoi implementation with a wrapper around strtod and strtol. It checks for the same conditions as stod and stoi, but provides the same interface as strtod and strtol.

Using that interface, I was also able to remove all calls to string::substr within datatable.cpp. This could dramatically speed up loading as it avoids copying parts of the loaded string over and over again.

Instead, it just uses a bit of pointers to move ahead on the original string, so no string copying is done.
