### PR TITLE
Added "object" as a parent of the Function class

### DIFF
--- a/python/splinter/function.py
+++ b/python/splinter/function.py
@@ -12,7 +12,7 @@ import pandas as pd
 import numpy as np
 
 
-class Function:
+class Function(object):
     def __init__(self):
         self._handle = None
         self._num_variables = None


### PR DESCRIPTION
In Python 2.7, examples don't work (and probably the whole library) because the Function class hasn't a "object" as parent, and so is not considered as a python object. Without this parent, the following error appears:

Traceback (most recent call last):
  File "bspline.py", line 30, in <module>
    b0 = splinter.BSplineBuilder(x, y, degree=0).build()
  File "/usr/local/lib/python2.7/dist-packages/splinter-3.0-py2.7.egg/splinter/bsplinebuilder.py", line 119, in build
    return BSpline(bspline_handle)
  File "/usr/local/lib/python2.7/dist-packages/splinter-3.0-py2.7.egg/splinter/bspline.py", line 16, in __init__
    super(BSpline, self).__init__()
TypeError: must be type, not classobj
Exception AttributeError: "BSpline instance has no attribute '_handle'" in <bound method BSpline.__del__ of <splinter.bspline.BSpline instance at 0x7f11247f2a28>> ignored

See also: http://stackoverflow.com/questions/9698614/super-raises-typeerror-must-be-type-not-classobj-for-new-style-class

Thanks,

