### PR TITLE
c++17 static_assert call changed to c++11 compatible one

### DIFF
--- a/src/bspline_utils.cpp
+++ b/src/bspline_utils.cpp
@@ -144,7 +144,7 @@ SparseMatrix compute_basis_function_matrix(const BSpline &bspline, const DataTab
     // Assume ColMajor storage order, in which case the inner vectors of SparseMatrix are columns.
     // If the storage order ever changes, change the reserve statement to:
     //     A.reserve( Eigen::VectorXi::Constant( num_samples, bspline.get_num_supported() ) );
-    static_assert( A.IsRowMajor == false );
+    static_assert( A.IsRowMajor == false, "" );
     // Although the number of non-zero elements per row equals bspline.get_num_supported(),
     // SparseMatrix::reserve requires a vector of size SparseMatrix::cols() a an argument;
     Eigen::VectorXi reserve_sizes( A.cols() );


### PR DESCRIPTION
Minimal change that caused a non-building code to compile:
CMakeLists seems to configure for c++11, but the call to static_assert( condition ) is c++17. Changed to static_assert( condition, message ), which is c++11.